### PR TITLE
Fix documentation link

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -56,4 +56,4 @@ example of some use cases for Spylon.
 .. |Travis| image:: https://travis-ci.org/maxpoint/spylon.svg
    :target: https://travis-ci.org/maxpoint/spylon
 .. |Docs| image:: https://img.shields.io/badge/docs-github-brightgreen.svg
-   :target: https://maxpoint.github.io/spylon/
+   :target: https://valassis-digital-media.github.io/spylon/docs/


### PR DESCRIPTION
The project link should also be fixed as it points to the same old link that now returns 404.